### PR TITLE
Fix EOFError

### DIFF
--- a/lib/mongo/connection/socket/ssl_socket.rb
+++ b/lib/mongo/connection/socket/ssl_socket.rb
@@ -83,12 +83,16 @@ module Mongo
     end
 
     def read(length, buffer)
-      if @op_timeout
-        Timeout::timeout(@op_timeout, OperationTimeout) do
+      begin
+        if @op_timeout
+          Timeout::timeout(@op_timeout, OperationTimeout) do
+            @socket.sysread(length, buffer)
+          end
+        else
           @socket.sysread(length, buffer)
         end
-      else
-        @socket.sysread(length, buffer)
+      rescue EOFError
+        raise ConnectionFailure
       end
     end
   end

--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -556,7 +556,7 @@ module Mongo
           @pool = nil
           @connection.unpin_pool
           @connection.refresh
-          if tries < 3 && !@socket && (!@command || Mongo::ReadPreference::secondary_ok?(@selector))
+          if tries < 3
             tries += 1
             retry
           else


### PR DESCRIPTION
Inspired on this patch available on the newer [`mongo-ruby-driver`](https://github.com/mongodb/mongo-ruby-driver/commit/348d355488a41cdfb6983f958c89b9ac051946e3). 

If the socket reaches EOF, we're going to raise `ConnectionFailure` and retry to connect. 